### PR TITLE
Change project URL workflow after github org rename

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
        - uses: actions/add-to-project@main
          with:
-           project-url: https://github.com/orgs/flowforge/projects/3
+           project-url: https://github.com/orgs/flowfuse/projects/3
            github-token: ${{ secrets.token }}
 
   add-to-artwork-board:
@@ -23,5 +23,5 @@ jobs:
          with:
            labeled: design, artwork
            label-operator: AND
-           project-url: https://github.com/orgs/flowforge/projects/10
+           project-url: https://github.com/orgs/flowfuse/projects/10
            github-token: ${{ secrets.token }}


### PR DESCRIPTION
## Description

Change project URL references after Github organisation rename from `flowforge` to `flowfuse`.

## Related Issue(s)

[213](https://github.com/flowforge/admin/issues/213)

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

