### PR TITLE
chore: Add terraform-aws-flowfuse repository to the list

### DIFF
--- a/flowfuse-repositories.yml
+++ b/flowfuse-repositories.yml
@@ -34,3 +34,4 @@ security
 usage-ping-collector
 website
 flow-renderer
+terraform-aws-flowfuse


### PR DESCRIPTION
## Description

Add `terraform-aws-flowfuse` repository to the list of maintained repos.

## Related Issue(s)

https://github.com/FlowFuse/admin/issues/307
https://github.com/FlowFuse/CloudProject/issues/390

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

