### PR TITLE
ci: Update `record-in-review` workflow to require PROJECT_ACCESS_TOKEN secret

### DIFF
--- a/.github/workflows/record-in-review.yml
+++ b/.github/workflows/record-in-review.yml
@@ -1,13 +1,10 @@
 name: Update Issue Status
 on:
   workflow_call:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - converted_to_draft
-      - ready_for_review
+    secrets:
+      PROJECT_ACCESS_TOKEN:
+        required: true
+
 jobs:
   mark_in_progress:
     if: ${{ github.event.pull_request.draft }}


### PR DESCRIPTION
## Description

Update `record-in-review` workflow to require `github.token` as PROJECT_ACCESS_TOKEN secret .
Additionally, remove `pull_requests` trigger since this workflow is used as a reusable one.

## Related Issue(s)


## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

