### PR TITLE
Add "Linked Customers" to bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug_report.yml
@@ -32,6 +32,12 @@ body:
         - Browser:
   validations:
     required: false
+- type: textarea
+  attributes:
+    label: Linked Customers
+    description: A bullet point list of the leads/customers that have been impacted by this problem
+    value: |
+      - Customer name and/or link to HubSpot contact
 - type: markdown
   attributes:
     value: |


### PR DESCRIPTION
## Description

Adds a section for us to link to Hubspot/Customer contacts so we can circle back when bugs are resolved that have blocked/impacted a customer