### PR TITLE
ci: Add possibility to add issues to `Dashboard Backlog` project

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -9,7 +9,7 @@ jobs:
   add-to-project-board:
     name: Add issue to project
     if: | 
-      github.repository != 'FlowFuse/website' ||
+      github.repository != 'FlowFuse/website' &&
       github.repository != 'FlowFuse/node-red-dashboard'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -30,7 +30,7 @@ jobs:
            github-token: ${{ secrets.token }}
   
   add-to-dashboard-backlog:
-    name: Add art requests to the Artwork board
+    name: Add issues to the Dashboard Backlog project board
     if: github.repository == 'FlowFuse/node-red-dashboard'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -8,10 +8,12 @@ on:
 jobs:
   add-to-project-board:
     name: Add issue to project
-    if: github.repository != 'FlowFuse/website'
+    if: | 
+      github.repository != 'FlowFuse/website' ||
+      github.repository != 'FlowFuse/node-red-dashboard'
     runs-on: ubuntu-latest
     steps:
-       - uses: actions/add-to-project@main
+       - uses: actions/add-to-project@v1.0.2
          with:
            project-url: https://github.com/orgs/FlowFuse/projects/3
            github-token: ${{ secrets.token }}
@@ -20,7 +22,7 @@ jobs:
     name: Add art requests to the Artwork board
     runs-on: ubuntu-latest
     steps:
-       - uses: actions/add-to-project@main
+       - uses: actions/add-to-project@v1.0.2
          with:
            labeled: design, artwork
            label-operator: AND
@@ -32,7 +34,7 @@ jobs:
     if: github.repository == 'FlowFuse/node-red-dashboard'
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/add-to-project@main
+        - uses: actions/add-to-project@v1.0.2
           with:
             labeled: needs-triage
             project-url: https://github.com/orgs/FlowFuse/projects/15

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -26,3 +26,14 @@ jobs:
            label-operator: AND
            project-url: https://github.com/orgs/FlowFuse/projects/10
            github-token: ${{ secrets.token }}
+  
+  add-to-dashboard-backlog:
+    name: Add art requests to the Artwork board
+    if: github.repository == 'FlowFuse/node-red-dashboard'
+    runs-on: ubuntu-latest
+    steps:
+        - uses: actions/add-to-project@main
+          with:
+            labeled: needs-triage
+            project-url: https://github.com/orgs/FlowFuse/projects/15
+            github-token: ${{ secrets.token }}


### PR DESCRIPTION
## Description

This pull request extends the `Add new issues to the Relevant Boards` by adding `add-to-dashboard-backlog` job responsible for adding issues created in `FlowFuse/node-red-dashboard` repository to the `Dashboard Backlog` project with `needs-triage` label.
Additionally, it replaces the branch reference for used action with the `v1.0.2` tag.  

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

