### PR TITLE
chore: Pin external actions to commit hash

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -13,7 +13,7 @@ jobs:
       github.repository != 'FlowFuse/node-red-dashboard'
     runs-on: ubuntu-latest
     steps:
-       - uses: actions/add-to-project@v1.0.2
+       - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
          with:
            project-url: https://github.com/orgs/FlowFuse/projects/3
            github-token: ${{ secrets.token }}
@@ -22,7 +22,7 @@ jobs:
     name: Add art requests to the Artwork board
     runs-on: ubuntu-latest
     steps:
-       - uses: actions/add-to-project@v1.0.2
+       - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
          with:
            labeled: design, artwork
            label-operator: AND
@@ -34,7 +34,7 @@ jobs:
     if: github.repository == 'FlowFuse/node-red-dashboard'
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/add-to-project@v1.0.2
+        - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
           with:
             labeled: needs-triage
             project-url: https://github.com/orgs/FlowFuse/projects/15

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -6,9 +6,9 @@ jobs:
   sync_labels:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Use Node.js 16.x
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
       with:
         node-version: 16.x
     - name: Install github-label-sync


### PR DESCRIPTION
## Description

This pull request pins external GitHub Actions to commit hashes instead of tags in all workflows.

## Related Issue(s)

https://github.com/FlowFuse/CloudProject/issues/663

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

