### PR TITLE
Add "nr-tables-nodes" repo

### DIFF
--- a/flowfuse-repositories.yml
+++ b/flowfuse-repositories.yml
@@ -34,6 +34,7 @@ nr-file-nodes
 nr-launcher
 nr-pmon
 nr-project-nodes
+nr-tables-nodes
 nr-tools-plugin
 security
 usage-ping-collector


### PR DESCRIPTION
## Description

Adds the `nr-tables-nodes` repo to the list as per the "New Repository" requirements detailed here: https://github.com/FlowFuse/admin/issues/408