### PR TITLE
Switch to GH App token in `Synchronize Labels` workflow

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -6,14 +6,22 @@ jobs:
   sync_labels:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Use Node.js 24
+    - name: Checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Setup Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: 24
     - name: Install github-label-sync
       run: npm install -g github-label-sync
+    - name: Generate a token
+      id: generate_token
+      uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      with:
+        client-id: ${{ secrets.GH_BOT_APP_ID}}
+        private-key: ${{ secrets.GH_BOT_APP_KEY }}
+        owner: ${{ github.repository_owner }}
     - name: Run github-label-sync
       run: sh ./sync-labels.sh
       env:
-        gh_token: ${{ secrets.PROJECT_ACCESS_TOKEN }}
+        gh_token: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
## Description

This pull request removes the reference to the PROJECT_ACCESS_TOKEN secret in a favour of short-lived GitHub Application token.

## Related Issue(s)

https://github.com/FlowFuse/engineering/issues/22

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

